### PR TITLE
사용자 기본 JPA Entity(Member) 생성

### DIFF
--- a/src/main/java/com/shareit/shareit/domain/Repository/MemberRepository.java
+++ b/src/main/java/com/shareit/shareit/domain/Repository/MemberRepository.java
@@ -1,0 +1,9 @@
+package com.shareit.shareit.domain.Repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.shareit.shareit.domain.entity.Member;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+	Member findAllBy(Long id);
+}

--- a/src/main/java/com/shareit/shareit/domain/Repository/MemberRepository.java
+++ b/src/main/java/com/shareit/shareit/domain/Repository/MemberRepository.java
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.shareit.shareit.domain.entity.Member;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
-	Member findAllBy(Long id);
+
 }

--- a/src/main/java/com/shareit/shareit/domain/Role.java
+++ b/src/main/java/com/shareit/shareit/domain/Role.java
@@ -4,9 +4,8 @@ import lombok.Getter;
 
 @Getter
 public enum Role {
-	ROLE_LENDER("ROLE_USER"),
-	ROLE_GRABBER("ROLE_GRABBER"),
-	ROLE_ADMIN("ROLE_ADMIN");
+	ROLE_USER("ROLE_USER"),
+	ROLE_SOCIAL("ROLE_SOCIAL");
 
 	String role;
 

--- a/src/main/java/com/shareit/shareit/domain/Role.java
+++ b/src/main/java/com/shareit/shareit/domain/Role.java
@@ -1,0 +1,20 @@
+package com.shareit.shareit.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum Role {
+	ROLE_LENDER("ROLE_USER"),
+	ROLE_GRABBER("ROLE_GRABBER"),
+	ROLE_ADMIN("ROLE_ADMIN");
+
+	String role;
+
+	Role(String role) {
+		this.role = role;
+	}
+
+	public String value() {
+		return role;
+	}
+}

--- a/src/main/java/com/shareit/shareit/domain/entity/Campus.java
+++ b/src/main/java/com/shareit/shareit/domain/entity/Campus.java
@@ -1,0 +1,34 @@
+package com.shareit.shareit.domain.entity;
+
+import com.shareit.shareit.domain.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "campus")
+public class Campus extends BaseEntity {
+	@Id
+	@Column(name = "id")
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long campusId;
+
+	@Column(name = "campus_name", length = 50)
+	private String campusName;
+
+	@Builder
+	public Campus(String campusName) {
+		this.campusName = campusName;
+
+	}
+}

--- a/src/main/java/com/shareit/shareit/domain/entity/Campus.java
+++ b/src/main/java/com/shareit/shareit/domain/entity/Campus.java
@@ -23,7 +23,7 @@ public class Campus extends BaseEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long campusId;
 
-	@Column(name = "campus_name", length = 50)
+	@Column(length = 50)
 	private String campusName;
 
 	@Builder

--- a/src/main/java/com/shareit/shareit/domain/entity/Member.java
+++ b/src/main/java/com/shareit/shareit/domain/entity/Member.java
@@ -1,0 +1,89 @@
+package com.shareit.shareit.domain.entity;
+
+import com.shareit.shareit.domain.BaseEntity;
+import com.shareit.shareit.domain.Role;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "member", uniqueConstraints = {
+	@UniqueConstraint(
+		name = "NICKNAME_UNIQUE",
+		columnNames = "NICKNAME"
+	)
+})
+
+public class Member extends BaseEntity {
+
+	@Id
+	@Column(name = "id", nullable = false)
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long memberId;
+
+	@Column(name = "email", length = 50)
+	private String email;
+
+	@Column(name = "password", length = 50)
+	private String password;
+
+	@Column(name = "nickname", length = 50)
+	private String nickname;
+
+	@Column(name = "phone_num", length = 50)
+	private String phoneNum;
+
+	@Column(name = "user_role")
+	@Enumerated(EnumType.STRING)
+	private Role userRole;
+
+	@Column(name = "address")
+	private String address;
+
+	@Column(name = "profile_image")
+	private String profileImage;
+
+	@Column(name = "social_id")
+	private String socialId;
+
+	@Column(name = "refresh_token")
+	private String refreshToken;
+
+	@Column(name = "profile_key")
+	private String profileKey;
+
+	@ManyToOne
+	@JoinColumn(name = "campus_id")
+	private Campus campus;
+
+	@Builder
+	public Member(String email, String password, String nickname, String phoneNum, Role userRole, String address,
+		String profileImage, String socialId, String refreshToken, String profileKey) {
+		this.email = email;
+		this.password = password;
+		this.nickname = nickname;
+		this.phoneNum = phoneNum;
+		this.userRole = userRole;
+		this.address = address;
+		this.profileImage = profileImage;
+		this.socialId = socialId;
+		this.refreshToken = refreshToken;
+		this.profileKey = profileKey;
+	}
+
+}

--- a/src/main/java/com/shareit/shareit/domain/entity/Member.java
+++ b/src/main/java/com/shareit/shareit/domain/entity/Member.java
@@ -25,7 +25,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "member", uniqueConstraints = {
 	@UniqueConstraint(
 		name = "NICKNAME_UNIQUE",
-		columnNames = "NICKNAME"
+		columnNames = "nickname"
 	)
 })
 
@@ -36,35 +36,28 @@ public class Member extends BaseEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long memberId;
 
-	@Column(name = "email", length = 50)
+	@Column(length = 50)
 	private String email;
 
-	@Column(name = "password", length = 50)
 	private String password;
 
-	@Column(name = "nickname", length = 50)
+	@Column(length = 50)
 	private String nickname;
 
-	@Column(name = "phone_num", length = 50)
+	@Column(length = 50)
 	private String phoneNum;
 
-	@Column(name = "user_role")
 	@Enumerated(EnumType.STRING)
 	private Role userRole;
 
-	@Column(name = "address")
 	private String address;
 
-	@Column(name = "profile_image")
 	private String profileImage;
 
-	@Column(name = "social_id")
 	private String socialId;
 
-	@Column(name = "refresh_token")
 	private String refreshToken;
 
-	@Column(name = "profile_key")
 	private String profileKey;
 
 	@ManyToOne


### PR DESCRIPTION
[x] 패키지 생성
### Entity, JpaReposiotry package
 - Entity, JpaRepository 전용 `Domain` 하위 패키지 생성

### Member.class
 - Campus Entity 연관관계 맵핑 (Campus.class 생성)
 - Builder 생성자 생성
 -  초기 개발 편의성을 위해 `nullable` (spring security 적용 때문에)
    추후 추가 대부분 추가 예정
 - 역할 `enum`적용 (String 저장)
 - nickname `uniqueConstraint` 적용

### Role.class
 - Memeber Entity의 enum 클래스
 - `value()` 메소드로 값 가져오기 
