### PR TITLE
Post 타입 추가 및 Repository 기능 추가, 소소한 기능 fix

### DIFF
--- a/src/main/java/com/shareit/shareit/domain/BaseEntity.java
+++ b/src/main/java/com/shareit/shareit/domain/BaseEntity.java
@@ -1,5 +1,7 @@
 package com.shareit.shareit.domain;
 
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.MappedSuperclass;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
@@ -11,26 +13,26 @@ import java.time.LocalDateTime;
 @MappedSuperclass
 public abstract class BaseEntity {
 
-    private LocalDateTime createdAt;
-    private LocalDateTime updatedAt;
+	private LocalDateTime createdAt;
+	private LocalDateTime updatedAt;
 
-    private ActiveStatus activeStatus;
+	@Enumerated(EnumType.STRING)
+	private ActiveStatus activeStatus = ActiveStatus.ACTIVE;
 
+	@PrePersist
+	public void prePersist() {
+		LocalDateTime now = LocalDateTime.now();
+		createdAt = now;
+		updatedAt = now;
+	}
 
-    @PrePersist
-    public void prePersist() {
-        LocalDateTime now = LocalDateTime.now();
-        createdAt = now;
-        updatedAt = now;
-    }
+	@PreUpdate
+	public void preUpdate() {
+		updatedAt = LocalDateTime.now();
+	}
 
-    @PreUpdate
-    public void preUpdate() {
-        updatedAt = LocalDateTime.now();
-    }
-
-    public void updateActiveStatus(ActiveStatus activeStatus){
-        this.activeStatus = activeStatus;
-    }
+	public void updateActiveStatus(ActiveStatus activeStatus) {
+		this.activeStatus = activeStatus;
+	}
 
 }

--- a/src/main/java/com/shareit/shareit/member/domain/entity/Member.java
+++ b/src/main/java/com/shareit/shareit/member/domain/entity/Member.java
@@ -71,7 +71,7 @@ public class Member extends BaseEntity {
 
 	@Builder
 	public Member(String email, String password, String nickname, String phoneNum, Role userRole, String address,
-		String profileImage, String socialId, String refreshToken, String profileKey) {
+		String profileImage, String socialId, String refreshToken, String profileKey, Campus campus) {
 		this.email = email;
 		this.password = password;
 		this.nickname = nickname;
@@ -82,6 +82,7 @@ public class Member extends BaseEntity {
 		this.socialId = socialId;
 		this.refreshToken = refreshToken;
 		this.profileKey = profileKey;
+		this.campus = campus;
 	}
 
 }

--- a/src/main/java/com/shareit/shareit/post/domain/PostType.java
+++ b/src/main/java/com/shareit/shareit/post/domain/PostType.java
@@ -1,0 +1,13 @@
+package com.shareit.shareit.post.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum PostType {
+	NEED("NEED"), LENT("LENT");
+
+	private final String postType;
+
+}

--- a/src/main/java/com/shareit/shareit/post/domain/entity/Post.java
+++ b/src/main/java/com/shareit/shareit/post/domain/entity/Post.java
@@ -68,16 +68,25 @@ public class Post extends BaseEntity {
 	private Set<Purchase> purchases;
 
 	@Builder
-	public Post(Campus campus, Member member, String hashTag, String content, String title, Long cost) {
+	public Post(Campus campus, Member member, String hashTag, String content, String title, Long cost, PostType postType) {
 		this.campus = campus;
 		this.member = member;
 		this.hashTag = hashTag;
 		this.content = content;
 		this.title = title;
 		this.cost = cost;
+		this.postType = postType;
 		this.postImages = new HashSet<>();
 		this.likes = new HashSet<>();
 		this.purchases = new HashSet<>();
+	}
+
+	// 연관 관계 편의 메서드
+	public void addPostImage(PostImage postImage) {
+		this.getPostImages().add(postImage);
+		if (postImage.getPost() != this){
+			postImage.addPost(this);
+		}
 	}
 
 }

--- a/src/main/java/com/shareit/shareit/post/domain/entity/Post.java
+++ b/src/main/java/com/shareit/shareit/post/domain/entity/Post.java
@@ -10,6 +10,7 @@ import com.shareit.shareit.domain.BaseEntity;
 import com.shareit.shareit.domain.entity.Campus;
 import com.shareit.shareit.like.domain.entity.Likes;
 import com.shareit.shareit.member.domain.entity.Member;
+import com.shareit.shareit.post.domain.PostType;
 import com.shareit.shareit.purchase.domain.entity.Purchase;
 
 import jakarta.persistence.CascadeType;
@@ -54,6 +55,8 @@ public class Post extends BaseEntity {
 	private String title;
 
 	private Long cost;
+
+	private PostType postType;
 
 	@OneToMany(mappedBy = "post", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
 	private Set<PostImage> postImages;

--- a/src/main/java/com/shareit/shareit/post/domain/entity/PostImage.java
+++ b/src/main/java/com/shareit/shareit/post/domain/entity/PostImage.java
@@ -1,6 +1,5 @@
 package com.shareit.shareit.post.domain.entity;
 
-import java.util.Set;
 
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
@@ -15,6 +14,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -35,5 +35,12 @@ public class PostImage extends BaseEntity {
 	private Post post;
 
 	private String imageKey;
+
+	@Builder
+	public PostImage(Post post, String imageKey) {
+		this.post = post;
+		this.imageKey = imageKey;
+
+	}
 
 }

--- a/src/main/java/com/shareit/shareit/post/domain/entity/PostImage.java
+++ b/src/main/java/com/shareit/shareit/post/domain/entity/PostImage.java
@@ -43,4 +43,14 @@ public class PostImage extends BaseEntity {
 
 	}
 
+	// 연관 관계 편의 메서드
+	public void addPost(Post post) {
+		if (this.post != post){
+			this.post = post;
+		}
+		if (!post.getPostImages().contains(this)){
+			post.addPostImage(this);
+		}
+	}
+
 }

--- a/src/main/java/com/shareit/shareit/post/repository/PostRepository.java
+++ b/src/main/java/com/shareit/shareit/post/repository/PostRepository.java
@@ -1,8 +1,19 @@
 package com.shareit.shareit.post.repository;
 
-import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
 
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.shareit.shareit.post.domain.PostType;
 import com.shareit.shareit.post.domain.entity.Post;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
+
+	@EntityGraph(attributePaths = {"postImages"})
+	@Query("select p from Post p where p.postType=:type")
+	List<Post> findAllWithImages(@Param("type") PostType postType);
+
 }

--- a/src/main/java/com/shareit/shareit/post/repository/PostRepository.java
+++ b/src/main/java/com/shareit/shareit/post/repository/PostRepository.java
@@ -1,8 +1,18 @@
 package com.shareit.shareit.post.repository;
 
-import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
 
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.shareit.shareit.post.domain.PostType;
 import com.shareit.shareit.post.domain.entity.Post;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
+
+	@EntityGraph(attributePaths = {"postImages"})
+	@Query("select p from Post p where p.postType=:type")
+	List<Post> findAllWithImages(@Param("type") PostType postType);
 }

--- a/src/main/java/com/shareit/shareit/post/repository/PostRepository.java
+++ b/src/main/java/com/shareit/shareit/post/repository/PostRepository.java
@@ -1,18 +1,8 @@
 package com.shareit.shareit.post.repository;
 
-import java.util.List;
-
-import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
-import com.shareit.shareit.post.domain.PostType;
 import com.shareit.shareit.post.domain.entity.Post;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
-
-	@EntityGraph(attributePaths = {"postImages"})
-	@Query("select p from Post p where p.postType=:type")
-	List<Post> findAllWithImages(@Param("type") PostType postType);
 }

--- a/src/test/java/com/shareit/shareit/repository/PostRepositoryTest.java
+++ b/src/test/java/com/shareit/shareit/repository/PostRepositoryTest.java
@@ -1,0 +1,179 @@
+package com.shareit.shareit.repository;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import com.shareit.shareit.domain.entity.Campus;
+import com.shareit.shareit.member.domain.entity.Member;
+import com.shareit.shareit.post.domain.PostType;
+import com.shareit.shareit.post.domain.entity.Post;
+import com.shareit.shareit.post.domain.entity.PostImage;
+import com.shareit.shareit.post.repository.PostRepository;
+
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@DataJpaTest
+@Transactional
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public class PostRepositoryTest {
+
+	private final String testString1 = "tes1";
+	private final String testString2 = "test2";
+
+	private final Long testCost1 = 0L;
+	private final Long testCost2 = 1000L;
+
+	private Campus testCampus;
+
+	private Member member1;
+	private Member member2;
+
+	@Autowired
+	private EntityManager em;
+	@Autowired
+	private PostRepository postRepository;
+
+	@BeforeEach
+	void beforeEach() {
+
+		testCampus = Campus.builder()
+			.campusName(testString1)
+			.build();
+
+		em.persist(testCampus);
+
+		member1 = Member.builder()
+			.email(testString1)
+			.password(testString1)
+			.nickname(testString1)
+			.campus(testCampus)
+			.build();
+
+		member2 = Member.builder()
+			.email(testString2)
+			.password(testString2)
+			.nickname(testString2)
+			.campus(testCampus)
+			.build();
+
+		em.persist(member1);
+		em.persist(member2);
+
+	}
+
+	@Test
+	@DisplayName("post 엔티티 생성")
+	void createPost() {
+		//Given
+		Post newPost = Post.builder()
+			.title(testString1)
+			.cost(testCost1)
+			.campus(testCampus)
+			.member(member1)
+			.build();
+
+		//When
+		Post savePost = postRepository.save(newPost);
+
+		//Then
+		log.info("new post id = {}", newPost.getId());
+
+		Post findPost = em.find(Post.class, newPost.getId());
+
+		assertThat(savePost).isEqualTo(findPost);
+	}
+
+	@Test
+	@DisplayName("post 엔티티 전체 찾아오기")
+	void findPosts() {
+		//Given
+		Post post1 = Post.builder()
+			.member(member1)
+			.title(testString1)
+			.content(testString1)
+			.campus(testCampus)
+			.cost(testCost1)
+			.build();
+
+		Post post2 = Post.builder()
+			.member(member2)
+			.title(testString2)
+			.content(testString2)
+			.campus(testCampus)
+			.cost(testCost2)
+			.build();
+
+		em.persist(post1);
+		em.persist(post2);
+
+		//When
+		List<Post> all = postRepository.findAll();
+
+		//Then
+		assertThat(all).hasSize(2);
+
+	}
+
+	@Test
+	@DisplayName("post 엔티티들 이미지와 함께 찾아오기")
+	void findPostsWithImages() {
+		//Given
+		Post post1 = Post.builder()
+			.member(member1)
+			.title(testString1)
+			.content(testString1)
+			.campus(testCampus)
+			.cost(testCost1)
+			.postType(PostType.NEED)
+			.build();
+
+		Post post2 = Post.builder()
+			.member(member2)
+			.title(testString2)
+			.content(testString2)
+			.campus(testCampus)
+			.cost(testCost2)
+			.postType(PostType.NEED)
+			.build();
+
+		em.persist(post1);
+		em.persist(post2);
+
+		PostImage postImage1 = PostImage.builder()
+			.imageKey(testString1)
+			.build();
+
+		PostImage postImage2 = PostImage.builder()
+			.imageKey(testString1)
+			.build();
+
+		PostImage postImage3 = PostImage.builder()
+			.imageKey(testString2)
+			.build();
+
+		post1.addPostImage(postImage1);
+		post1.addPostImage(postImage2);
+		post2.addPostImage(postImage3);
+
+		//When
+		List<Post> findPosts = postRepository.findAllWithImages(PostType.NEED);
+
+		//Then
+		findPosts.forEach(post -> {
+			assertThat(post.getPostImages()).isNotEmpty();
+			log.info("post image size = {}", post.getPostImages().size());
+		});
+
+	}
+}


### PR DESCRIPTION
[변경 사항]
- BaseEntity 에서 Active status default로 Active 상태로 변경 및 컨벤션 적용
- Member 엔티티에서 Campus 필드 빌더에 추가 (빠져 있었음)

[추가 사항]
- PostType 추가 (빌려줄게요, 필요해요)
- Post-PostImage 연관관계 편의 메서드 추가
- PostRepository test 추가
- Image와 함께 Post 모두를 조회하는 메서드 추가 (PostRepository)
